### PR TITLE
Version 0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ during the test, including parameters and headers.
     * Expose Journal API for accessing journal
 * 0.3.2
     * Fixes bug where `block_domains` is ignored if a simulation file isn't specified in `StaticSimulation`
+* 0.3.3
+    * Registers `simulated` marker used by plugin
 
 ## Meta
 

--- a/pytest_hoverfly_wrapper/plugin.py
+++ b/pytest_hoverfly_wrapper/plugin.py
@@ -112,6 +112,11 @@ class DeferPlugin(object):
 def pytest_configure(config):
     if 0:
         config.pluginmanager.register(DeferPlugin())
+    
+    config.addinivalue_line(
+        "markers",
+        "simulated(simulation_obj): Makes use of recorded responses which are sent in response to web requests made in tests, rather than receiving responses from their intended targets"
+    )
 
 
 def simulate(file, hf_port, admin_port, node, sim_list=()):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name="pytest-hoverfly-wrapper",
-    version="0.3.2",
+    version="0.3.3",
     author="Veli Akiner",
     author_email="veli@kopernio.com",
     maintainer="Veli Akiner",

--- a/tests/test_hoverfly_wrapper.py
+++ b/tests/test_hoverfly_wrapper.py
@@ -90,6 +90,27 @@ def test_template_block_domain_json():
     template_block_domain_json("reddit.com")
 
 
+def test_marker_registered(testdir):
+    """Make sure that the plugin's markers are registered."""
+
+    # create a temporary pytest test module
+    testdir.makepyfile(
+        """
+        from pytest_hoverfly_wrapper.simulations import GeneratedSimulation
+        import pytest
+        import requests
+
+        @pytest.mark.simulated(GeneratedSimulation())
+        def test_sth(setup_hoverfly, mocker):
+            pass
+    """
+    )
+
+    # run pytest with the following cmd args
+    result = testdir.runpytest("--strict")
+
+    assert result.ret == 0
+
 # TODO: end-to-end tests covering:
 #  using static sims,
 #  recording and using sims,

--- a/veracode-log.txt
+++ b/veracode-log.txt
@@ -8,3 +8,4 @@ Veracode Security Scan results:
 0.3.0 -  VL4+SCA
 0.3.1 -  VL4+SCA
 0.3.2 -  VL4+SCA
+0.3.3 -  VL4+SCA


### PR DESCRIPTION
Registers a marker used by the plugin, so that usage with the `--strict` flag does not cause the tests to error.