### PR TITLE
add f-string

### DIFF
--- a/pytest_hoverfly_wrapper/plugin.py
+++ b/pytest_hoverfly_wrapper/plugin.py
@@ -84,7 +84,8 @@ def pytest_addoption(parser):
 
 @pytest.fixture
 def test_log_directory():
-    directory = os.path.join("hoverfly_logs")
+    foo = ""
+    directory = os.path.join(f"hoverfly_logs{foo}")
     if not os.path.exists(directory):
         os.mkdir(directory)
     return directory


### PR DESCRIPTION
test PR to see if tox is working correctly: jobs for py 3.5/3.6 should fail with an f-string added